### PR TITLE
Rework validation

### DIFF
--- a/contrib/eraser/training/config/eraser.yaml
+++ b/contrib/eraser/training/config/eraser.yaml
@@ -26,6 +26,8 @@ learning_rate: 3e-5 # see Appendix A.1
 optimizer: AdamW
 num_steps: [1, 4]
 log_interval: 500
+val_check_interval: 1000
+limit_val_batches: 2
 resume_from_checkpoint: false
 max_epochs: 50
 save_interval: 5000

--- a/contrib/eraser/training/train_eraser.py
+++ b/contrib/eraser/training/train_eraser.py
@@ -236,6 +236,7 @@ def get_filter_mappers(
                             "before.jpg": "before",
                             "after.jpg": "after",
                             "mask.png": "mask",
+                            "__key__": "uid"
                         }
                     )
                 ),
@@ -309,7 +310,7 @@ def get_data_module(
     random.shuffle(train_shards_path_or_urls_unbraced)
 
     # data config
-    data_config = DataModuleConfig(
+    train_data_config = DataModuleConfig(
         shards_path_or_urls=train_shards_path_or_urls_unbraced,
         decoder="pil",
         shuffle_before_split_by_node_buffer_size=20,
@@ -319,8 +320,6 @@ def get_data_module(
         per_worker_batch_size=batch_size,
         num_workers=min(10, len(train_shards_path_or_urls_unbraced)),
     )
-
-    train_data_config = data_config
 
     # VALIDATION
     validation_filters_mappers = get_filter_mappers(image_size)
@@ -332,18 +331,16 @@ def get_data_module(
             braceexpand.braceexpand(validation_shards_path_or_url)
         )
 
-    data_config = DataModuleConfig(
+    validation_data_config = DataModuleConfig(
         shards_path_or_urls=validation_shards_path_or_urls_unbraced,
         decoder="pil",
-        shuffle_before_split_by_node_buffer_size=10,
-        shuffle_before_split_by_workers_buffer_size=10,
-        shuffle_before_filter_mappers_buffer_size=10,
-        shuffle_after_filter_mappers_buffer_size=10,
+        shuffle_before_split_by_node_buffer_size=None,
+        shuffle_before_split_by_workers_buffer_size=None,
+        shuffle_before_filter_mappers_buffer_size=None,
+        shuffle_after_filter_mappers_buffer_size=None,
         per_worker_batch_size=batch_size,
         num_workers=min(10, len(train_shards_path_or_urls_unbraced)),
     )
-
-    validation_data_config = data_config
 
     # data module
     data_module = DataModule(
@@ -392,6 +389,8 @@ def main(
     bridge_noise_sigma: float = 0.005,
     save_interval: int = 1000,
     path_config: str = None,
+    val_check_interval: int = 1000,
+    limit_val_batches: int = 2,
     image_size: Tuple[int, int] | List[int] = (480, 640),  # (H, W)
 ):
     model = get_model(
@@ -441,6 +440,11 @@ def main(
             "input_shape": None,
             "num_steps": num_steps,
         },
+        column_visualization_keys=[
+            ("before", f"{num_step}_steps") # see lbm_model.py
+            for num_step in num_steps
+        ],
+        metrics=["lpips", "psnr", "pieapp", "dists"]
     )
     if (
         os.path.exists(save_ckpt_path)
@@ -537,8 +541,8 @@ def main(
         ],
         num_sanity_val_steps=0,
         precision="bf16-mixed",
-        limit_val_batches=2,
-        val_check_interval=1000,
+        limit_val_batches=limit_val_batches,
+        val_check_interval=val_check_interval,
         max_epochs=max_epochs,
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ wandb==0.16.2
 webdataset>=0.2.86
 kornia==0.8.0
 neptune>=1.0
+piq>=0.8.0

--- a/src/lbm/models/base/base_model.py
+++ b/src/lbm/models/base/base_model.py
@@ -49,10 +49,6 @@ class BaseModel(nn.Module):
             self.dtype = dtype
         return self
 
-    def compute_metrics(self, batch: Dict[str, Any], *args, **kwargs):
-        """Compute the metrics"""
-        return {}
-
     def sample(self, batch: Dict[str, Any], *args, **kwargs):
         """Sample from the model"""
         return {}

--- a/src/lbm/models/lbm/lbm_model.py
+++ b/src/lbm/models/lbm/lbm_model.py
@@ -501,7 +501,7 @@ class LBMModel(BaseModel):
                 z = source_image
 
             with torch.autocast(dtype=self.dtype, device_type="cuda"):
-                logs[f"samples_{num_step}_steps"] = self.sample(
+                logs[f"{num_step}_steps"] = self.sample(
                     z,
                     num_steps=num_step,
                     conditioner_inputs=batch,

--- a/src/lbm/trainer/loggers.py
+++ b/src/lbm/trainer/loggers.py
@@ -10,7 +10,7 @@ from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import Callback
 from pytorch_lightning.utilities import rank_zero_only
 from torchvision.utils import make_grid
-
+from lbm.data.datasets.collation_fn import custom_collation_fn
 from ..trainer import TrainingPipeline
 
 logging.basicConfig(level=logging.INFO)
@@ -92,238 +92,6 @@ def wrap_text(
     lines.append(current_line)
     return lines
 
-
-class WandbSampleLogger(Callback):
-    """
-    Logger for logging samples to wandb. This logger is used to log images, text, and metrics to wandb.
-
-    Args:
-        log_batch_freq (int): The frequency of logging samples to wandb. Default is 100.
-    """
-
-    def __init__(self, log_batch_freq: int = 100):
-        super().__init__()
-        self.log_batch_freq = log_batch_freq
-
-    def on_train_batch_end(
-        self,
-        trainer: Trainer,
-        pl_module: TrainingPipeline,
-        outputs: Dict[str, Any],
-        batch: Any,
-        batch_idx: int,
-    ) -> None:
-        self.log_samples(trainer, pl_module, outputs, batch, batch_idx, split="train")
-        self._process_logs(trainer, outputs, split="train")
-
-    def on_validation_batch_end(
-        self,
-        trainer: Trainer,
-        pl_module: TrainingPipeline,
-        outputs: Dict[str, Any],
-        batch: Any,
-        batch_idx: int,
-    ) -> None:
-        self.log_samples(trainer, pl_module, outputs, batch, batch_idx, split="val")
-        self._process_logs(trainer, outputs, split="val")
-
-    @rank_zero_only
-    @torch.no_grad()
-    def log_samples(
-        self,
-        trainer: Trainer,
-        pl_module: TrainingPipeline,
-        outputs: Dict[str, Any],
-        batch: Dict[str, Any],
-        batch_idx: int,
-        split: str = "train",
-    ) -> None:
-        if hasattr(pl_module, "log_samples"):
-            if batch_idx % self.log_batch_freq == 0:
-                is_training = pl_module.training
-                if is_training:
-                    pl_module.eval()
-
-                logs = pl_module.log_samples(batch)
-                logs = self._process_logs(trainer, logs, split=split)
-
-                if is_training:
-                    pl_module.train()
-        else:
-            logging.warning(
-                "log_img method not found in LightningModule. Skipping image logging."
-            )
-
-    @rank_zero_only
-    def _process_logs(
-        self, trainer, logs: Dict[str, Any], rescale=True, split="train"
-    ) -> Dict[str, Any]:
-        for key, value in logs.items():
-            if isinstance(value, torch.Tensor):
-                value = value.detach().cpu()
-                if value.dim() == 4:
-                    images = value
-                    if rescale:
-                        images = (images + 1.0) / 2.0
-                    grid = make_grid(images, nrow=4)
-                    grid = grid.permute(1, 2, 0)
-                    grid = grid.mul(255).clamp(0, 255).to(torch.uint8)
-                    logs[key] = grid.numpy()
-                    trainer.logger.experiment.log(
-                        {f"{key}/{split}": [wandb.Image(Image.fromarray(logs[key]))]},
-                        step=trainer.global_step,
-                    )
-
-                # Scalar tensor
-                if value.dim() == 1 or value.dim() == 0:
-                    value = value.float().numpy()
-                    trainer.logger.experiment.log(
-                        {f"{key}/{split}": value}, step=trainer.global_step
-                    )
-
-            # list of string (e.g. text)
-            if isinstance(value, list):
-                if isinstance(value[0], str):
-                    pil_image_texts = create_grid_texts(value)
-                    wandb_image = wandb.Image(pil_image_texts)
-                    trainer.logger.experiment.log(
-                        {f"{key}/{split}": [wandb_image]},
-                        step=trainer.global_step,
-                    )
-
-            # dict of tensors (e.g. metrics)
-            if isinstance(value, dict):
-                for k, v in value.items():
-                    if isinstance(v, torch.Tensor):
-                        value[k] = v.detach().cpu().numpy()
-                trainer.logger.experiment.log(
-                    {f"{key}/{split}": value}, step=trainer.global_step
-                )
-
-            if isinstance(value, int) or isinstance(value, float):
-                trainer.logger.experiment.log(
-                    {f"{key}/{split}": value}, step=trainer.global_step
-                )
-
-        return logs
-
-
-class TensorBoardSampleLogger(Callback):
-    """
-    Logger for logging samples to tensorboard. This logger is used to log images, text, and metrics to tensorboard.
-
-    Args:
-        log_batch_freq (int): The frequency of logging samples to tensorboard. Default is 100.
-    """
-
-    def __init__(self, log_batch_freq: int = 100):
-        super().__init__()
-        self.log_batch_freq = log_batch_freq
-
-    def on_train_batch_end(
-        self,
-        trainer: Trainer,
-        pl_module: TrainingPipeline,
-        outputs: Dict[str, Any],
-        batch: Any,
-        batch_idx: int,
-    ) -> None:
-        self.log_samples(trainer, pl_module, outputs, batch, batch_idx, split="train")
-        self._process_logs(trainer, outputs, split="train")
-
-    def on_validation_batch_end(
-        self,
-        trainer: Trainer,
-        pl_module: TrainingPipeline,
-        outputs: Dict[str, Any],
-        batch: Any,
-        batch_idx: int,
-    ) -> None:
-        self.log_samples(trainer, pl_module, outputs, batch, batch_idx, split="val")
-        self._process_logs(trainer, outputs, split="val")
-
-    @rank_zero_only
-    @torch.no_grad()
-    def log_samples(
-        self,
-        trainer: Trainer,
-        pl_module: TrainingPipeline,
-        outputs: Dict[str, Any],
-        batch: Dict[str, Any],
-        batch_idx: int,
-        split: str = "train",
-    ) -> None:
-        if hasattr(pl_module, "log_samples"):
-            if batch_idx % self.log_batch_freq == 0:
-                is_training = pl_module.training
-                if is_training:
-                    pl_module.eval()
-
-                logs = pl_module.log_samples(batch)
-                logs = self._process_logs(trainer, logs, split=split)
-
-                if is_training:
-                    pl_module.train()
-        else:
-            logging.warning(
-                "log_img method not found in LightningModule. Skipping image logging."
-            )
-
-    @rank_zero_only
-    def _process_logs(
-        self, trainer, logs: Dict[str, Any], rescale=True, split="train"
-    ) -> Dict[str, Any]:
-        for key, value in logs.items():
-            if isinstance(value, torch.Tensor):
-                value = value.detach().cpu()
-                if value.dim() == 4:
-                    images = value
-                    if rescale:
-                        images = (images + 1.0) / 2.0
-                    grid = make_grid(images, nrow=4)
-                    # grid = grid.permute(1, 2, 0)
-                    grid = grid.mul(255).clamp(0, 255).to(torch.uint8)
-                    logs[key] = grid.numpy()
-                    trainer.logger.experiment.add_image(
-                        f"{key}/{split}",
-                        logs[key],
-                        trainer.global_step,
-                    )
-
-                # Scalar tensor
-                if value.dim() == 1 or value.dim() == 0:
-                    value = value.float().numpy()
-                    trainer.logger.experiment.add_scalar(
-                        f"{key}/{split}", value, trainer.global_step
-                    )
-
-            # list of string (e.g. text)
-            if isinstance(value, list):
-                if isinstance(value[0], str):
-                    pil_image_texts = create_grid_texts(value)
-                    trainer.logger.experiment.add_image(
-                        f"{key}/{split}",
-                        np.transpose(np.array(pil_image_texts), (2, 0, 1)),
-                        trainer.global_step,
-                    )
-
-            # dict of tensors (e.g. metrics)
-            if isinstance(value, dict):
-                for k, v in value.items():
-                    if isinstance(v, torch.Tensor):
-                        value[k] = v.detach().cpu().numpy()
-                trainer.logger.experiment.add_scalar(
-                    f"{key}/{split}", value, trainer.global_step
-                )
-
-            if isinstance(value, int) or isinstance(value, float):
-                trainer.logger.experiment.add_scalar(
-                    f"{key}/{split}", value, trainer.global_step
-                )
-
-        return logs
-
-
 class NeptuneLogger(Callback):
     """
     Logger for logging samples to Neptune. This logger is used to log images, text, and metrics to Neptune.
@@ -335,7 +103,8 @@ class NeptuneLogger(Callback):
     def __init__(self, log_batch_freq: int = 100):
         super().__init__()
         self.log_batch_freq = log_batch_freq
-
+        self.val_metrics: list[Dict[str, Any]] = []
+    
     def on_train_batch_end(
         self,
         trainer: Trainer,
@@ -344,8 +113,10 @@ class NeptuneLogger(Callback):
         batch: Any,
         batch_idx: int,
     ) -> None:
-        self.log_samples(trainer, pl_module, outputs, batch, batch_idx, split="train")
         self._process_logs(trainer, outputs, split="train")
+    
+    def on_validation_start(self, trainer: Trainer, pl_module: TrainingPipeline) -> None:
+        self.val_metrics = []
 
     def on_validation_batch_end(
         self,
@@ -355,41 +126,64 @@ class NeptuneLogger(Callback):
         batch: Any,
         batch_idx: int,
     ) -> None:
-        self.log_samples(trainer, pl_module, outputs, batch, batch_idx, split="val")
-        self._process_logs(trainer, outputs, split="val")
+        assert outputs["visuals"] is not None
+        assert outputs["metrics"] is not None
 
-    @rank_zero_only
-    @torch.no_grad()
-    def log_samples(
+        metrics = outputs.pop("metrics")
+        visuals = outputs.pop("visuals")
+        self._process_logs(trainer, visuals, split="val", rescale=True)
+
+        # the metrics are aggregated at each batch
+        # and stored in self.val_metrics
+        # they are logged at the end of the validation epoch
+        first_key = pl_module.log_keys[0]
+        self.val_metrics.append({
+            # batch_size is not always the same 
+            # especially with wds.batched(..., partial=True) (which is the default)
+            "batch_size": batch[first_key].shape[0],
+            **metrics,
+        })
+    
+    def on_validation_end(
         self,
         trainer: Trainer,
-        pl_module: TrainingPipeline,
-        outputs: Dict[str, Any],
-        batch: Dict[str, Any],
-        batch_idx: int,
-        split: str = "train",
+        pl_module: TrainingPipeline
     ) -> None:
-        if hasattr(pl_module, "log_samples"):
-            if batch_idx % self.log_batch_freq == 0:
-                is_training = pl_module.training
-                if is_training:
-                    pl_module.eval()
+        
+        collated_metrics = custom_collation_fn(self.val_metrics)
 
-                logs = pl_module.log_samples(batch)
-                logs = self._process_logs(trainer, logs, split=split)
-
-                if is_training:
-                    pl_module.train()
-        else:
-            logging.warning(
-                "log_samples method not found in LightningModule. Skipping image logging."
-            )
+        n_items = sum([self.val_metrics[i]["batch_size"] for i in range(len(self.val_metrics))])
+        if n_items == 0:
+            logging.warning("No items in validation metrics. Skipping metric aggregation.")
+            return
+        
+        # reduce metrics with a mean weighted by batch size
+        # TODO: handle/test multi-gpu aggregation
+        aggregated_metrics = {
+            key: np.sum(
+                collated_metrics[key][index] * self.val_metrics[index]["batch_size"]
+                for index in range(len(self.val_metrics))
+             ) / n_items
+            for key in collated_metrics.keys() if key != "batch_size" 
+        }
+           
+        self._process_logs(
+            trainer,
+            aggregated_metrics,
+            split="val"
+        )
+        self.val_metrics = []
 
     @rank_zero_only
     def _process_logs(
-        self, trainer, logs: Dict[str, Any], rescale=True, split="train"
+        self,
+        trainer,
+        logs: Dict[str, Any],
+        rescale : bool =True,
+        split: str ="train",
     ) -> Dict[str, Any]:
         for key, value in logs.items():
+            full_key = f"{split}/{key}"
             if isinstance(value, torch.Tensor):
                 value = value.detach().cpu()
                 if value.dim() == 4:
@@ -400,7 +194,7 @@ class NeptuneLogger(Callback):
                     grid = grid.permute(1, 2, 0)
                     grid = grid.mul(255).clamp(0, 255).to(torch.uint8)
                     logs[key] = grid.numpy()
-                    trainer.logger.experiment[f"{key}/{split}"].append(
+                    trainer.logger.experiment[full_key].append(
                         NeptuneFile.as_image(Image.fromarray(logs[key])),
                         step=trainer.global_step,
                     )
@@ -408,7 +202,7 @@ class NeptuneLogger(Callback):
                 # Scalar tensor
                 if value.dim() == 1 or value.dim() == 0:
                     value = value.float().numpy()
-                    trainer.logger.experiment[f"{key}/{split}"].append(
+                    trainer.logger.experiment[full_key].append(
                         value, step=trainer.global_step
                     )
 
@@ -417,7 +211,7 @@ class NeptuneLogger(Callback):
                 if isinstance(value[0], str):
                     pil_image_texts = create_grid_texts(value)
                     neptune_image = NeptuneFile.as_image(Image.fromarray(pil_image_texts))
-                    trainer.logger.experiment[f"{key}/{split}"].append(
+                    trainer.logger.experiment[full_key].append(
                         neptune_image, step=trainer.global_step
                     )
 
@@ -427,12 +221,12 @@ class NeptuneLogger(Callback):
                     if isinstance(v, torch.Tensor):
                         value[k] = v.detach().cpu().numpy()
 
-                trainer.logger.experiment[f"{key}/{split}"].append(
+                trainer.logger.experiment[full_key].append(
                     value, step=trainer.global_step
                 )
 
             if isinstance(value, int) or isinstance(value, float):
-                trainer.logger.experiment[f"{key}/{split}"].append(
+                trainer.logger.experiment[full_key].append(
                     value, step=trainer.global_step
                 )
 

--- a/src/lbm/trainer/trainer.py
+++ b/src/lbm/trainer/trainer.py
@@ -6,12 +6,61 @@ from typing import Any, Dict
 
 import pytorch_lightning as pl
 import torch
+import piq
 
 from ..models.base.base_model import BaseModel
 from .training_config import TrainingConfig
+from .utils import mix_images_column_wise
 
 logging.basicConfig(level=logging.INFO)
 
+class MetricHandler:
+    def __init__(self, metrics: list[str], device: torch.device) -> None:
+        self.metrics = metrics
+        self.lpips_metric = piq.LPIPS() if "lpips" in metrics else None
+        self.pieapp_metric = piq.PieAPP() if "pieapp" in metrics else None
+        self.dists_metric = piq.DISTS() if "dists" in metrics else None
+        self.to(device)
+
+    def compute(self, prediction: torch.Tensor, target: torch.Tensor) -> dict[str, Any]:
+        """
+        Compute the metrics between the prediction and the target
+        It returns an average over the batch
+        
+        Args:
+            prediction (torch.Tensor): The predicted image tensor of shape (B, C, H, W), normalized in [-1, 1]
+            target (torch.Tensor): The target image tensor of shape (B, C, H, W), normalized in [-1, 1]
+        Returns:
+            dict[str, Any]: A dictionary containing the computed metrics
+        """
+
+        # From [-1, 1] to [0, 1] for PIQ metrics
+        prediction = ((prediction + 1) / 2.0).clamp(0,1).to(self.device)
+        target = ((target + 1) / 2.0).clamp(0,1).to(self.device)
+
+        results = {}
+        for metric in self.metrics:
+            match metric:
+                case "lpips":
+                    assert self.lpips_metric is not None
+                    results["lpips"] = self.lpips_metric(prediction, target)
+                case "pieapp":
+                    assert self.pieapp_metric is not None
+                    results["pieapp"] = self.pieapp_metric(prediction, target)
+                case "dists":
+                    assert self.dists_metric is not None
+                    results["dists"] = self.dists_metric(prediction, target)
+                case "psnr":
+                    results["psnr"] = piq.psnr(prediction, target)
+                case _:
+                    raise ValueError(f"Unknown metric {metric}")
+        return results
+
+    def to(self, device: torch.device) -> None:
+        self.lpips_metric.to(device)
+        self.pieapp_metric.to(device)
+        self.dists_metric.to(device)
+        self.device = device
 
 class TrainingPipeline(pl.LightningModule):
     """
@@ -54,6 +103,8 @@ class TrainingPipeline(pl.LightningModule):
             log_keys = []
 
         self.log_keys = log_keys
+        self.column_visualization_keys = pipeline_config.column_visualization_keys
+        self.metric_handler = MetricHandler(pipeline_config.metrics, device=self.device) if pipeline_config.metrics is not None else None
 
     def on_fit_start(self) -> None:
         self.model.on_fit_start(device=self.device)
@@ -161,39 +212,138 @@ class TrainingPipeline(pl.LightningModule):
 
     def training_step(self, train_batch: Dict[str, Any], batch_idx: int) -> dict:
         model_output = self.model(train_batch)
-        loss = model_output["loss"]
-        logging.info(f"loss: {loss}")
+        logging.info(f"loss: {model_output['loss']}")
+
         return {
-            "loss": loss,
+            "loss": model_output["loss"],
+            "latent_recon_loss": model_output["latent_recon_loss"],
+            "pixel_recon_loss": model_output["pixel_recon_loss"],
             "batch_idx": batch_idx,
         }
 
     def validation_step(self, val_batch: Dict[str, Any], val_idx: int) -> dict:
-        loss = self.model(val_batch, device=self.device)["loss"]
-
-        metrics = self.model.compute_metrics(val_batch)
-
-        return {"loss": loss, "metrics": metrics}
-
-    def log_samples(self, batch: Dict[str, Any]):
-        logging.debug("log_samples")
-        logs = self.model.log_samples(
-            batch,
+        model_output = self.model(val_batch, device=self.device)
+        samples = self.model.log_samples(
+            batch=val_batch,
             **self.log_samples_model_kwargs,
         )
+        grid_samples = self.build_grids(
+            val_batch, 
+            samples, 
+            mask_keys=["mask"] # TODO: do not hardcode this
+        )
+        other_metrics = self.compute_metrics(val_batch, samples) if self.metric_handler is not None else {}
+        return {
+            "metrics": {
+                "loss": model_output["loss"],
+                "latent_recon_loss": model_output["latent_recon_loss"],
+                "pixel_recon_loss": model_output["pixel_recon_loss"],
+                **other_metrics
+            },
+            "visuals": grid_samples
+        }
+    
+    def build_grids(
+            self, 
+            batch: Dict[str, Any], 
+            samples: Dict[str, Any], 
+            mask_keys: list[str] | None = None,
+            uid_key: str = "uid"
+    ) -> Dict[str, Any]:
+        output_logs: Dict[str, Any] = {}
 
-        if logs is not None:
-            N = min([logs[keys].shape[0] for keys in logs])
-        else:
-            N = 0
+        assert uid_key in batch, f"uid_key {uid_key} not in batch"
 
-        # Log inputs
-        if self.log_keys is not None:
-            for key in self.log_keys:
-                if key in batch:
-                    if N > 0:
-                        logs[key] = batch[key][:N]
-                    else:
-                        logs[key] = batch[key]
+        all_images = {
+            **{
+                key: batch[key].to(self.device)
+                for key in self.log_keys if key in batch
+            },
+            **{
+                key: samples[key].to(self.device)
+                for key in samples
+            }
+        }
+        samples_keys = list(samples.keys())
 
-        return logs
+        # renormalize masks from [0, 1] to [-1, 1]
+        if mask_keys is not None:
+            for key in mask_keys:
+                if key in all_images:
+                    all_images[key] = (all_images[key] - 0.5) * 2.0
+
+        _, _, h, w = list(all_images.values())[0].shape
+        shape = (1, 3, h, w)
+
+        # we log one grid image per batch element
+        # The grid contains:
+        # - the input images (self.log_keys) in the first row (n_columns = len(self.log_keys))
+        # - the samples (samples) in the second rows (n_columns = len(samples))
+        # - the column-wise mix of the images in the third rows (n_columns = len(column_visualization_keys))
+
+        n_columns = max(len(self.log_keys), len(samples), len(self.column_visualization_keys))
+        batch_size = min([samples[k].shape[0] for k in samples])
+        for image_index in range(0, batch_size):
+            grid: list[list[torch.Tensor]] = []
+
+            first_row = []
+            for key_index in range(0, n_columns):
+                if key_index < len(self.log_keys):
+                    cell = all_images[self.log_keys[key_index]][image_index:image_index+1]
+                else:
+                    cell = torch.zeros(shape, device=self.device)  # pad with black images
+                
+                assert cell.shape == shape, f"Cell shape {cell.shape} does not match expected shape {shape}"
+                first_row.append(cell)
+            
+            grid.append(first_row)
+
+            second_row = []
+            for key_index in range(0, n_columns):
+                if key_index < len(samples_keys):
+                    cell = all_images[samples_keys[key_index]][image_index:image_index+1]
+                else:
+                    cell = torch.zeros(shape, device=self.device)  # pad with black images
+                
+                assert cell.shape == shape, f"Cell shape {cell.shape} does not match expected shape {shape}"
+                second_row.append(cell)
+
+            grid.append(second_row)
+
+            third_row = []
+            for key_index in range(0, n_columns):
+                if key_index < len(self.column_visualization_keys):
+                    first_key, second_key = self.column_visualization_keys[key_index]
+                    cell = mix_images_column_wise(
+                        all_images[first_key][image_index:image_index+1],
+                        all_images[second_key][image_index:image_index+1]
+                    )
+                else:
+                    cell = torch.zeros(shape, device=self.device)  # pad with black images
+                
+                assert cell.shape == shape, f"Cell shape {cell.shape} does not match expected shape {shape}"
+                third_row.append(cell)
+            
+            grid.append(third_row)
+
+            
+            image_key = batch[uid_key][image_index].replace("/", "_")
+            output_logs[f"image_{image_key}"] = torch.cat(
+                [torch.cat(row, dim=3) for row in grid], 
+                dim=2
+            )
+
+        return output_logs
+
+    def compute_metrics(self, batch: Dict[str, Any], samples: Dict[str, Any]) -> Dict[str, Any]:
+        assert self.metric_handler is not None
+        output_logs: Dict[str, Any] = {}
+
+        for sample_key, sample in samples.items():
+            metrics = self.metric_handler.compute(
+                prediction=sample,
+                target=batch[self.model.target_key]
+            )
+            for metric_key, value in metrics.items():
+                output_logs[f"{metric_key}_{sample_key}"] = value
+        return output_logs

--- a/src/lbm/trainer/training_config.py
+++ b/src/lbm/trainer/training_config.py
@@ -1,5 +1,5 @@
 from dataclasses import field
-from typing import List, Literal, Optional, Union
+from typing import List, Literal, Optional, Union, Tuple
 
 from pydantic.dataclasses import dataclass
 
@@ -70,6 +70,7 @@ class TrainingConfig(BaseConfig):
     lr_scheduler_frequency: Optional[int] = 1
     metrics: Optional[List[str]] = None
     tracking_metrics: Optional[List[str]] = None
+    column_visualization_keys: List[Tuple[str, str]] = field(default_factory=lambda: [])
     backup_every: int = 50
     trainable_params: List[str] = field(default_factory=lambda: ["./*"])
     log_keys: Optional[Union[str, List[str]]] = "txt"

--- a/src/lbm/trainer/utils.py
+++ b/src/lbm/trainer/utils.py
@@ -191,3 +191,37 @@ class StateDictRenamer:
                 checkpoint_state_dict[new_key] = checkpoint_state_dict.pop(old_key)
                 logging.info(f"Renaming {old_key} to {new_key}")
         return checkpoint_state_dict
+
+def mix_images_column_wise(a: torch.Tensor, b: torch.Tensor, column_width: int = 20) -> torch.Tensor:
+    """
+    Mix two batched images column-wise along width.
+
+    Args:
+        a (torch.Tensor): Tensor of shape (b, c, h, w)
+        b (torch.Tensor): Tensor of shape (b, c, h, w)
+        column_width (int): Width (in pixels) of each alternating column block.
+
+    Returns:
+        torch.Tensor: Mixed tensor of shape (b, c, h, w)
+    """
+    assert a.shape == b.shape, "Inputs must have the same shape"
+    assert a.ndim == 4, "Inputs must be 4D tensors (b, c, h, w)"
+    _, _, _, w = a.shape
+
+    device = a.device
+    dtype = a.dtype
+
+    b = b.to(device=device, dtype=dtype)
+
+    # Build mask pattern [1, 1, 0, 0, 1, 1, 0, 0, ...] along width dimension
+    mask = torch.zeros(w, dtype=torch.bool, device=device)
+    toggle = True
+    for x in range(0, w, column_width):
+        x_end = min(x + column_width, w)
+        mask[x:x_end] = toggle
+        toggle = not toggle
+
+    # with shape (1, 1, 1, w) it broadcasts mask to (b, c, h, w)
+    mask = mask.view(1, 1, 1, w)
+    
+    return torch.where(mask, a, b)


### PR DESCRIPTION
Rework the way the `validation_step` is done.

* Grid vizualisation 
* PIQ metrics aggregated over the whole validation

Outside scope : 
* Remove wandb and tensorboard loggers for now, cause current changes make them obsolete
* Multi-gpu metric aggregation (will do it as a follow-up step)
* Log training samples


## Grid

### Legend

| | First Column | Second Column | Third Column |
|---|---|---|---|
| First Row | Before image | After Image (Ground truth) | Mask |
| Second Row | 1-steps-pred | 4-steps-pred | <blank> |
| Third Row | 1-steps-pred vs Before | 4-steps-pred vs before | <blank> |

### Example

<img width="1920" height="1440" alt="a014a148-b95b-448a-ac8d-4b53f4099fcb" src="https://github.com/user-attachments/assets/7148ea4e-f228-4e34-ab86-671c81b68562" />

