### PR TITLE
CenterCrop to [960, 536]

### DIFF
--- a/contrib/eraser/training/config/eraser.yaml
+++ b/contrib/eraser/training/config/eraser.yaml
@@ -12,7 +12,8 @@ latent_loss_weight: 1.0
 bridge_noise_sigma: 0.05 # see Appendix A.1
 conditioning_images_keys: []
 conditioning_masks_keys: []
-image_size: [480, 640] # (H, W)
+image_size: [536, 960] # (H, W)
+resize_mode: CenterCrop # CenterCrop or Resize
 
 train_shards: 
 - "data/RORD-processed/train-{000000..000412}.tar"

--- a/contrib/eraser/training/config/eraser.yaml
+++ b/contrib/eraser/training/config/eraser.yaml
@@ -12,7 +12,7 @@ latent_loss_weight: 1.0
 bridge_noise_sigma: 0.05 # see Appendix A.1
 conditioning_images_keys: []
 conditioning_masks_keys: []
-image_size: [536, 960] # (H, W)
+image_size: [536, 960] # (H, W), while original RORD dimension is [H=540, W=960]
 resize_mode: CenterCrop # CenterCrop or Resize
 
 train_shards: 

--- a/contrib/eraser/training/train_eraser.py
+++ b/contrib/eraser/training/train_eraser.py
@@ -472,8 +472,24 @@ def get_model(
     return model
 
 def get_filter_mappers(
-    image_size: Tuple[int, int] # (height, width)
-):
+    image_size: Tuple[int, int], # (height, width)
+    resize_mode: str = "Resize" # CenterCrop or Resize
+) -> list[MapperWrapper | KeyFilter]:
+
+    match resize_mode:
+        case "CenterCrop":
+            resize_args = {
+                "size": image_size,
+            }
+        case "Resize":
+            resize_args = {
+                "size": image_size,
+                "interpolation": InterpolationMode.NEAREST_EXACT,
+            }
+        case _:
+            raise ValueError(f"Unsupported resize_mode: {resize_mode}")
+        
+        
     filters_mappers = [
         KeyFilter(KeyFilterConfig(keys=["before.jpg", "after.jpg", "mask.png", "__key__"], verbose=True)),
         MapperWrapper(
@@ -491,39 +507,30 @@ def get_filter_mappers(
                 TorchvisionMapper(
                     TorchvisionMapperConfig(
                         key="before",
-                        transforms=["ToTensor", "Resize"],
+                        transforms=["ToTensor", resize_mode],
                         transforms_kwargs=[
                             {},
-                            {
-                                "size": image_size,
-                                "interpolation": InterpolationMode.NEAREST_EXACT,
-                            },
+                            resize_args,
                         ],
                     )
                 ),
                 TorchvisionMapper(
                     TorchvisionMapperConfig(
                         key="after",
-                        transforms=["ToTensor", "Resize"],
+                        transforms=["ToTensor", resize_mode],
                         transforms_kwargs=[
                             {},
-                            {
-                                "size": image_size,
-                                "interpolation": InterpolationMode.NEAREST_EXACT,
-                            },
+                            resize_args,
                         ],
                     )
                 ),
                 TorchvisionMapper(
                     TorchvisionMapperConfig(
                         key="mask",
-                        transforms=["ToTensor", "Resize", "Normalize"],
+                        transforms=["ToTensor", resize_mode, "Normalize"],
                         transforms_kwargs=[
                             {},
-                            {
-                                "size": image_size,
-                                "interpolation": InterpolationMode.NEAREST_EXACT,
-                            },
+                            resize_args,
                             {"mean": 0.0, "std": 1.0},
                         ],
                     )
@@ -554,11 +561,12 @@ def get_data_module(
     train_shards: List[str],
     validation_shards: List[str],
     batch_size: int,
-    image_size: Tuple[int, int] # (height, width)
+    image_size: Tuple[int, int], # (height, width)
+    resize_mode: str = "Resize" # CenterCrop or Resize
 ):
 
     # TRAIN
-    train_filters_mappers = get_filter_mappers(image_size)
+    train_filters_mappers = get_filter_mappers(image_size, resize_mode)
 
     # unbrace urls
     train_shards_path_or_urls_unbraced = []
@@ -590,7 +598,7 @@ def get_data_module(
     )
 
     # VALIDATION
-    validation_filters_mappers = get_filter_mappers(image_size)
+    validation_filters_mappers = get_filter_mappers(image_size, resize_mode)
 
     # unbrace urls
     validation_shards_path_or_urls_unbraced = []
@@ -659,6 +667,7 @@ def main(
     save_interval: int = 1000,
     path_config: str = None,
     image_size: Tuple[int, int] | List[int] = (480, 640),  # (H, W)
+    resize_mode: str = "Resize" # CenterCrop or Resize
 ):
     model = get_model(
         backbone_signature=backbone_signature,
@@ -688,7 +697,8 @@ def main(
         train_shards=train_shards,
         validation_shards=validation_shards,
         batch_size=batch_size,
-        image_size=image_size
+        image_size=image_size,
+        resize_mode=resize_mode,
     )
 
     train_parameters = ["denoiser.*"]


### PR DESCRIPTION
RORD dataset size is [960, 540] but 540 is not a multiple of 8 (then not compatible with SD1.5 output size, and then it fails when running LPIPS metrics)

For now, I suggest to center crop the images to [960, 536] for now, so we are doing zero-stretching of the images.