### PR TITLE
monitor val/loss in ModelCheckpoint

### DIFF
--- a/contrib/eraser/training/train_eraser.py
+++ b/contrib/eraser/training/train_eraser.py
@@ -826,6 +826,8 @@ def main(
                 every_n_train_steps=save_interval,
                 save_last=True,
                 save_top_k=save_top_k,
+                monitor="val/loss",       # metric to rank by
+                mode="min",
             ),
         ],
         num_sanity_val_steps=0,


### PR DESCRIPTION
Follow up #21 

Currently facing
```
lightning_fabric.utilities.exceptions.MisconfigurationException: ModelCheckpoint(save_top_k=25, monitor=None) is not a valid configuration. No quantity for top_k to track.
```