### PR TITLE
RemovalBench - resizing

### DIFF
--- a/contrib/eraser/datasets/preprocess_removalbench.py
+++ b/contrib/eraser/datasets/preprocess_removalbench.py
@@ -78,7 +78,7 @@ def main() -> None:
         shard_path = args.out_dir / f"{args.prefix}-{i:04d}.tar"
         print(f"🧩 Writing {shard_path} with {end - start} samples...")
 
-        with tarfile.open(shard_path, "w") as tar:
+        with tarfile.open(shard_path, "w", dereference=True) as tar:
             for idx, (img, gt, mask, stem) in enumerate(triples[start:end], start=start + 1):
                 base = str(idx)
                 tar.add(img, arcname=f"{base}-{stem}.before.png")

--- a/contrib/eraser/training/config/eraser.yaml
+++ b/contrib/eraser/training/config/eraser.yaml
@@ -13,12 +13,12 @@ bridge_noise_sigma: 0.05 # see Appendix A.1
 conditioning_images_keys: []
 conditioning_masks_keys: []
 image_size: [536, 960] # (H, W), while original RORD dimension is [H=540, W=960]
-resize_mode: CenterCrop # CenterCrop or Resize
 
 train_shards: 
 - "data/RORD-processed/train-{000000..000412}.tar"
 validation_shards: 
 - "data/BaiLing/RemovalBench-{0000..0007}.tar" # 8 shards, one per GPU
+val_img_extension: ".png"
 
 batch_size: 4
 learning_rate: 3e-5 # see Appendix A.1

--- a/contrib/eraser/training/train_eraser.py
+++ b/contrib/eraser/training/train_eraser.py
@@ -44,6 +44,8 @@ from lbm.data.mappers import (
     TorchvisionMapperConfig,
     RandomPixelMasking,
     RandomPixelMaskingConfig,
+    ResizeAndCenterCrop,
+    ResizeAndCenterCropConfig,
 )
 from lbm.models.embedders import (
     ConditionerWrapper,
@@ -138,7 +140,7 @@ class EraserLogger(Callback):
                 continue
             pred = pred.clamp(-1, 1)
             metric = self.metrics[metric_key]
-            gt = batch[pl_module.model.target_key]
+            gt = batch[pl_module.model.target_key].clamp(-1, 1)
 
             metric.update(pred.to(self.device), gt.to(self.device))
         
@@ -480,68 +482,52 @@ def get_model(
 
 def get_filter_mappers(
     image_size: Tuple[int, int], # (height, width)
-    resize_mode: str = "Resize" # CenterCrop or Resize
+    img_extension: str = ".jpg",
+    mask_extension: str = ".png",
 ) -> list[MapperWrapper | KeyFilter]:
-
-    match resize_mode:
-        case "CenterCrop":
-            resize_args = {
-                "size": image_size,
-            }
-        case "Resize":
-            resize_args = {
-                "size": image_size,
-                "interpolation": InterpolationMode.NEAREST_EXACT,
-            }
-        case _:
-            raise ValueError(f"Unsupported resize_mode: {resize_mode}")
-        
-        
+    
+    key_map = {
+        f"before{img_extension}": "before",
+        f"after{img_extension}": "after",
+        f"mask{mask_extension}": "mask",
+        f"__key__": "uid"
+    }
     filters_mappers = [
-        KeyFilter(KeyFilterConfig(keys=["before.jpg", "after.jpg", "mask.png", "__key__"], verbose=True)),
+        KeyFilter(KeyFilterConfig(keys=key_map.keys(), verbose=True)),
         MapperWrapper(
             [
                 KeyRenameMapper(
                     KeyRenameMapperConfig(
-                        key_map={
-                            "before.jpg": "before",
-                            "after.jpg": "after",
-                            "mask.png": "mask",
-                            "__key__": "uid",
-                        }
+                        key_map=key_map
                     )
                 ),
                 TorchvisionMapper(
                     TorchvisionMapperConfig(
                         key="before",
-                        transforms=["ToTensor", resize_mode],
-                        transforms_kwargs=[
-                            {},
-                            resize_args,
-                        ],
+                        transforms=["ToTensor"],
+                        transforms_kwargs=[{}],
                     )
                 ),
                 TorchvisionMapper(
                     TorchvisionMapperConfig(
                         key="after",
-                        transforms=["ToTensor", resize_mode],
-                        transforms_kwargs=[
-                            {},
-                            resize_args,
-                        ],
+                        transforms=["ToTensor"],
+                        transforms_kwargs=[{}],
                     )
                 ),
                 TorchvisionMapper(
                     TorchvisionMapperConfig(
                         key="mask",
-                        transforms=["ToTensor", resize_mode, "Normalize"],
+                        transforms=["ToTensor", "Normalize"],
                         transforms_kwargs=[
                             {},
-                            resize_args,
-                            {"mean": 0.0, "std": 1.0},
+                            {"mean": 0.0, "std": 1.0}
                         ],
                     )
                 ),
+                ResizeAndCenterCrop(ResizeAndCenterCropConfig(key="before",image_size=image_size)),
+                ResizeAndCenterCrop(ResizeAndCenterCropConfig(key="after",image_size=image_size)),
+                ResizeAndCenterCrop(ResizeAndCenterCropConfig(key="mask",image_size=image_size)),
                 # Random pixel masking is made on [0, 1] tensors (before RescaleMapper)
                 RandomPixelMasking(
                     RandomPixelMaskingConfig(
@@ -567,13 +553,17 @@ def get_filter_mappers(
 def get_data_module(
     train_shards: List[str],
     validation_shards: List[str],
+    train_img_extension: str,
+    val_img_extension: str,
     batch_size: int,
     image_size: Tuple[int, int], # (height, width)
-    resize_mode: str = "Resize" # CenterCrop or Resize
-):
+) -> DataModule:
 
     # TRAIN
-    train_filters_mappers = get_filter_mappers(image_size, resize_mode)
+    train_filters_mappers = get_filter_mappers(
+        image_size=image_size,
+        img_extension=train_img_extension
+    )
 
     # unbrace urls
     train_shards_path_or_urls_unbraced = []
@@ -605,7 +595,10 @@ def get_data_module(
     )
 
     # VALIDATION
-    validation_filters_mappers = get_filter_mappers(image_size, resize_mode)
+    validation_filters_mappers = get_filter_mappers(
+        image_size=image_size,
+        img_extension=val_img_extension
+    )
 
     # unbrace urls
     validation_shards_path_or_urls_unbraced = []
@@ -678,7 +671,8 @@ def main(
     save_top_k: int = 1,
     path_config: str = None,
     image_size: Tuple[int, int] | List[int] = (480, 640),  # (H, W)
-    resize_mode: str = "Resize" # CenterCrop or Resize
+    train_img_extension: str = ".jpg",
+    val_img_extension: str = ".jpg",
 ):
     model = get_model(
         backbone_signature=backbone_signature,
@@ -709,7 +703,8 @@ def main(
         validation_shards=validation_shards,
         batch_size=batch_size,
         image_size=image_size,
-        resize_mode=resize_mode,
+        train_img_extension=train_img_extension,
+        val_img_extension=val_img_extension
     )
 
     train_parameters = ["denoiser.*"]

--- a/src/lbm/data/mappers/__init__.py
+++ b/src/lbm/data/mappers/__init__.py
@@ -1,10 +1,11 @@
 from .base import BaseMapper
-from .mappers import KeyRenameMapper, RescaleMapper, TorchvisionMapper, RandomPixelMasking
+from .mappers import KeyRenameMapper, RescaleMapper, TorchvisionMapper, RandomPixelMasking, ResizeAndCenterCrop
 from .mappers_config import (
     KeyRenameMapperConfig,
     RescaleMapperConfig,
     TorchvisionMapperConfig,
     RandomPixelMaskingConfig,
+    ResizeAndCenterCropConfig
 )
 from .mappers_wrapper import MapperWrapper
 
@@ -19,4 +20,6 @@ __all__ = [
     "RandomPixelMaskingConfig",
     "MapperWrapper",
     "RandomPixelMasking",
+    "ResizeAndCenterCrop",
+    "ResizeAndCenterCropConfig",
 ]

--- a/src/lbm/data/mappers/mappers.py
+++ b/src/lbm/data/mappers/mappers.py
@@ -1,5 +1,6 @@
-from typing import Any, Dict
+from typing import Any, Dict, Tuple
 
+from numpy import size
 from torchvision import transforms
 import torchvision.transforms.functional as F
 import torch
@@ -9,7 +10,8 @@ from .mappers_config import (
     KeyRenameMapperConfig,
     RescaleMapperConfig,
     TorchvisionMapperConfig,
-    RandomPixelMaskingConfig
+    RandomPixelMaskingConfig,
+    ResizeAndCenterCropConfig
 )
 from torch import Tensor
 
@@ -169,3 +171,44 @@ class RandomPixelMasking(BaseMapper):
         
         noise = torch.empty_like(image).uniform_(generator=generator)
         return image * (1 - mask) + noise * mask
+
+class ResizeAndCenterCrop(BaseMapper):
+    """
+    Resize/Center-Crop the image so we do not stretch the pixel.
+
+    Args:
+        config (ResizeAndCenterCropConfig): Configuration for the mapper
+    """
+
+    def __init__(self, config: ResizeAndCenterCropConfig):
+        super().__init__(config)
+
+    def __call__(self, batch: Dict[str, Any], *args, **kwrags) -> Dict[str, Any]:
+        batch[self.output_key] = self._process(
+            image=batch[self.config.key],
+            size=self.config.image_size,
+            interpolation=self.config.interpolation,
+        )
+        return batch
+
+    def _process(
+        self, 
+        image: Tensor, 
+        size: Tuple[int, int], # h, w
+        interpolation: transforms.InterpolationMode
+    ) -> Tensor:
+        target_height, target_width = size
+        target_ratio = target_width / target_height
+        image_width, image_height = F.get_image_size(image)
+        image_ratio = image_width / image_height
+        if image_ratio > target_ratio:
+            # Image is wider than target ratio, resize based on height
+            new_height = target_height
+            new_width = int(target_height * image_ratio)
+        else:
+            # Image is taller than target ratio, resize based on width
+            new_width = target_width
+            new_height = int(target_width / image_ratio)
+
+        image = F.resize(image, size=(new_height, new_width), interpolation=self.config.interpolation)
+        return F.center_crop(image, size)

--- a/src/lbm/data/mappers/mappers_config.py
+++ b/src/lbm/data/mappers/mappers_config.py
@@ -1,4 +1,5 @@
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
+from torchvision import transforms
 
 from pydantic.dataclasses import dataclass
 
@@ -122,3 +123,17 @@ class RandomPixelMaskingConfig(BaseMapperConfig):
     key: str = "image"
     mask_key: str = "mask"
     seed_key: str | None = None
+
+class ResizeAndCenterCropConfig(BaseMapperConfig):
+    """
+    Resize/Center-Crop the image so we do not stretch the pixel.
+
+    Args:
+        key (str): Key to apply the resizing and cropping to.
+        image_size (Tuple[int, int]): Size of the output image (height, width).
+        interpolation (int): Interpolation mode to use for resizing. Defaults to `PIL.Image.NEAREST`.
+    """
+
+    key: str = "image"
+    image_size: Tuple[int, int] = (480, 640)  # (H, W)
+    interpolation: transforms.InterpolationMode = transforms.InterpolationMode.NEAREST


### PR DESCRIPTION
Follow up #19 

Note: in RemovalBench, there is a mix of 1024x1024 images and 2299x1536 images, so a one-size-fit-all "Resize" or "CenterCrop" (or a combination of `torchvision.transforms`) does not work.