### PR TITLE
rm `save_interval` to perform checkpointing after validation

### DIFF
--- a/contrib/eraser/training/config/eraser.yaml
+++ b/contrib/eraser/training/config/eraser.yaml
@@ -34,7 +34,6 @@ val_check_interval: 500 # 500 means every 8 (batch) * 4 (gpus) * 500 = 16000 tra
 
 # Checkpointing
 resume_from_checkpoint: false
-save_interval: 500 # synced with val_check_interval
 # Each checkpoint is 5.1GB, 25 checkpoints = 125GB
 # 25 * 500 = 12500 last steps are covered
 save_top_k: 25

--- a/contrib/eraser/training/train_eraser.py
+++ b/contrib/eraser/training/train_eraser.py
@@ -669,7 +669,6 @@ def main(
     resume_from_checkpoint: bool = True,
     max_epochs: int = 100,
     bridge_noise_sigma: float = 0.005,
-    save_interval: int = 1000,
     limit_val_batches: int = 2,
     val_check_interval: int = 1000,
     save_top_k: int = 1,
@@ -814,7 +813,6 @@ def main(
             LearningRateMonitor(logging_interval="step"),
             ModelCheckpoint(
                 dirpath=save_ckpt_path,
-                every_n_train_steps=save_interval,
                 save_last=True,
                 save_top_k=save_top_k,
                 monitor="val/loss",       # metric to rank by


### PR DESCRIPTION
When we set both `save_interval` and `val_check_interval`, `ModelCheckpoint` is triggered in the `on_train_batch_end` hook before the validation is made.

Removing it fixes the issue, as explained in the [doc](https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.callbacks.ModelCheckpoint.html)

<img width="592" height="192" alt="Capture d’écran 2025-10-24 à 14 48 13" src="https://github.com/user-attachments/assets/c6ec27fa-6630-43d7-8cbc-875ada8544b4" />
