### PR TITLE
resume_from_checkpoint is str

### DIFF
--- a/contrib/eraser/training/config/eraser.yaml
+++ b/contrib/eraser/training/config/eraser.yaml
@@ -33,7 +33,9 @@ limit_val_batches: 16 # 16 x 1 (val_batch_size) x 4 GPUs = 64 samples for valida
 val_check_interval: 500 # 500 means every 8 (batch) * 4 (gpus) * 500 = 16000 training samples
 
 # Checkpointing
-resume_from_checkpoint: false
+# Uncomment to resume from last checkpoint
+# resume_from_checkpoint: "./checkpoints/last.ckpt"
+resume_from_checkpoint: null
 # Each checkpoint is 5.1GB, 25 checkpoints = 125GB
 # 25 * 500 = 12500 last steps are covered
 save_top_k: 25

--- a/contrib/eraser/training/train_eraser.py
+++ b/contrib/eraser/training/train_eraser.py
@@ -718,7 +718,7 @@ def main(
             "num_steps": num_steps,
         },
     )
-    if resume_from_checkpoint:
+    if resume_from_checkpoint is not None:
         assert os.path.exists(resume_from_checkpoint), f"Checkpoint path {resume_from_checkpoint} does not exist."
         start_ckpt = resume_from_checkpoint
         print(f"Resuming from checkpoint: {resume_from_checkpoint}")

--- a/contrib/eraser/training/train_eraser.py
+++ b/contrib/eraser/training/train_eraser.py
@@ -721,7 +721,7 @@ def main(
     if resume_from_checkpoint is not None:
         assert os.path.exists(resume_from_checkpoint), f"Checkpoint path {resume_from_checkpoint} does not exist."
         start_ckpt = resume_from_checkpoint
-        print(f"Resuming from checkpoint: {resume_from_checkpoint}")
+        logging.info(f"Resuming from checkpoint: {resume_from_checkpoint}")
 
     else:
         start_ckpt = None

--- a/contrib/eraser/training/train_eraser.py
+++ b/contrib/eraser/training/train_eraser.py
@@ -666,7 +666,7 @@ def main(
     save_ckpt_path: str = "./checkpoints",
     gradient_clip_val: Optional[float] = None,
     log_interval: int = 10,
-    resume_from_checkpoint: bool = True,
+    resume_from_checkpoint: Optional[str] = None,
     max_epochs: int = 100,
     bridge_noise_sigma: float = 0.005,
     limit_val_batches: int = 2,
@@ -718,13 +718,10 @@ def main(
             "num_steps": num_steps,
         },
     )
-    if (
-        os.path.exists(save_ckpt_path)
-        and resume_from_checkpoint
-        and "last.ckpt" in os.listdir(save_ckpt_path)
-    ):
-        start_ckpt = f"{save_ckpt_path}/last.ckpt"
-        print(f"Resuming from checkpoint: {start_ckpt}")
+    if resume_from_checkpoint:
+        assert os.path.exists(resume_from_checkpoint), f"Checkpoint path {resume_from_checkpoint} does not exist."
+        start_ckpt = resume_from_checkpoint
+        print(f"Resuming from checkpoint: {resume_from_checkpoint}")
 
     else:
         start_ckpt = None
@@ -804,7 +801,9 @@ def main(
         strategy=strategy,
         default_root_dir="logs",
         logger=loggers.NeptuneLogger(
-            project=neptune_project, name=run_name, log_model_checkpoints=False
+            project=neptune_project, 
+            name=run_name, 
+            log_model_checkpoints=False
         ),
         callbacks=[
             EraserLogger(


### PR DESCRIPTION
Currently, 
* Training saves `last.ckpt` or `last-v1.ckpt` ...
* It resumes from `last.ckpt` only

It's error-prone, a simple mitigation is to explicitly put the checkpoint we are resuming from in `resume_from_checkpoint`